### PR TITLE
Add Github action to label workflows

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,10 @@
+name: Add `orange` label to new issues and PR's
+on: [issues, pull_request]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: DataBiosphere/azul-github-labeler-action@releases/v4
+      with:
+        repo-token: "${{secrets.GITHUB_TOKEN}}"
+        label: orange


### PR DESCRIPTION
This PR adds [this label.yml](https://github.com/DataBiosphere/azul/blob/develop/.github/workflows/label.yml) to the repo to automatically label new issues with the "orange" label.

This relates to #1.