### PR TITLE
Add script to sync Github labels

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,10 @@
+name: Add `orange` label to new issues and pull requests
+on: [issues, pull_request]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: DataBiosphere/azul-github-labeler-action@releases/v4
+      with:
+        repo-token: "${{secrets.GITHUB_TOKEN}}"
+        label: orange

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+sync_labels.log

--- a/Readme.md
+++ b/Readme.md
@@ -1,0 +1,58 @@
+# Sync Github Labels
+
+This script will synchronize labels idempotently between two Github repositories.
+
+## Before You Begin
+
+Before using this script, it requires the use of a Gitub API key. This can be created
+by logging into Github (using an account that has the ability to create/remove labels
+from the source and destination repositories), going to Settings > Developer > Access Tokens,
+and creating a new access token with the ability to control repositories.
+
+Once you have the API key, set the `GITHUB_API_KEY` environment variable to the access
+token you created.
+
+## Basic Usage
+
+Call this script on the command line, and pass it the source and destination repo:
+
+```
+./sync_labels.py [--FLAGS] SOURCE_REPO DEST_REPO
+```
+
+## Normal Operation
+
+The basic mode of operation is to pass the script the full name of a source repository 
+and a destination repository:
+
+```
+./sync_labels.py foo/hello-world bar/hello-world
+```
+
+## `--dry-run`: Dry Run Mode
+
+To do a dry-run of the label sync actions and see a summary of what labels would be added or deleted,
+use the `--dry-run` or `-n` flag:
+
+```
+./sync_labels.py --dry-run foo/hello-world bar/hello-world
+./sync_labels.py -n foo/hello-world bar/hello-world
+```
+
+This will run the script but will skip any API calls that create or delete labels.
+
+## `--delete`: Delete Mode
+
+The default behavior of the script is to look for labels that are in the source repo and 
+not in the destination repo. Labels that are in the destination repo but not in the source repo
+are ignored.
+
+By adding the `--delete` flag, the script will delete any label that is in the destination repo
+that is not in the source repo.
+
+```
+./sync_labels --delete foo/hello-world bar/hello-world
+./sync_labels -d foo/hello-world bar/hello-world
+```
+
+**Warning: This operation is destructive! Make sure to use the `--dry-run` flag first.**

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+certifi==2019.11.28
+chardet==3.0.4
+Deprecated==1.2.7
+idna==2.9
+PyGithub==1.47
+PyJWT==1.7.1
+requests==2.23.0
+urllib3==1.25.8
+wrapt==1.12.1

--- a/sync_labels.py
+++ b/sync_labels.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+import sys
+import os
+import json
+import logging
+import argparse
+from github import Github, GithubException, UnknownObjectException, BadCredentialsException
+
+"""
+Sync Github Labels
+
+Synchronize labels idempotently between two Github repositories.
+"""
+
+
+# Set up logging
+log_name = "sync_labels.log"
+fh = logging.FileHandler(log_name)
+fh.setFormatter(logging.Formatter(fmt="[%(asctime)s] %(message)s", datefmt="%Y-%m-%d %H:%M:%S"))
+sh = logging.StreamHandler(sys.stdout)
+sh.setFormatter(logging.Formatter(fmt="%(message)s"))
+logging.basicConfig(level=logging.INFO, handlers=[fh, sh])
+logger = logging.getLogger(os.path.basename(__file__))
+
+
+def sync_labels(src_repo, dst_repo, dry_run, delete):
+    """
+    Main subroutine: sync labels between source/destination Github repos
+
+    :param src_repo: full repo name for source of labels
+    :param dst_repo: full repo name for destination of label actions
+    :param dry_run: do a dry run, do not perform the actions
+    :param delete: delete labels that are in destination but not in source
+    """
+
+    # Get PyGithub objects representing repos
+    gh = Github(get_access_token())
+    try:
+        src = gh.get_repo(src_repo)
+    except UnknownObjectException as e:
+        msg = f"The source repository specified does not exist: {src_repo}"
+        logging.exception(msg)
+        raise RuntimeError(msg)
+    try:
+        dst = gh.get_repo(dst_repo)
+    except UnknownObjectException as e:
+        msg = f"The destination repository specified does not exist: {dst_repo}"
+        logging.exception(msg)
+        raise RuntimeError(msg)
+
+    # Create list of labels to add/delete
+    src_labels = list(src.get_labels())
+    src_label_names = {j.name for j in src_labels}
+    dst_labels = list(dst.get_labels())
+    dst_label_names = {j.name for j in dst_labels}
+    dst_add = src_label_names - dst_label_names
+    dst_upd = src_label_names.intersection(dst_label_names)
+    dst_del = dst_label_names - src_label_names
+
+    # Show summary of what actions will be taken
+    if len(dst_add) > 0:
+        logger.info(f"The following labels will be created in {dst_repo}:")
+        print_list(list(dst_add), " [+] ")
+
+    if len(dst_upd) > 0:
+        logger.info(f"The following labels will be updated in {dst_repo}:")
+        print_list(list(dst_upd), " [u] ")
+
+    if delete:
+        if len(dst_del) > 0:
+            logger.info(f"The following labels will be deleted in {dst_repo}:")
+            print_list(list(dst_del), " [-] ")
+
+    # Add new labels
+    add_ok = []
+    add_fail = []
+    for name in dst_add:
+        if dry_run:
+            add_ok.append(name)
+        else:
+            print_sameline("Adding label: " + name)
+            label = src.get_label(name)
+            color = label.color
+            description = label.description
+            try:
+                dst.create_label(name, color, description)
+            except GithubException:
+                logging.exception(f"Error adding label: {name}")
+                add_fail.append(name)
+            else:
+                add_ok.append(name)
+
+    # Update existing labels
+    upd_ok = []
+    upd_fail = []
+    for name in dst_upd:
+        if dry_run:
+            upd_ok.append(name)
+        else:
+            print_sameline("Updating label: " + name)
+            label = src.get_label(name)
+            dst_label = dst.get_label(name)
+            color = label.color
+            description = label.description
+            try:
+                dst_label.edit(name, color, description)
+            except GithubException:
+                logging.exception(f"Error updating label: {name}")
+                upd_fail.append(name)
+            else:
+                upd_ok.append(name)
+
+    # Delete labels
+    del_ok = []
+    del_fail = []
+    if delete:
+        for name in dst_del:
+            if dry_run:
+                del_ok.append(name)
+            else:
+                print_sameline("Deleting label: " + name)
+                label = dst.get_label(name)
+                try:
+                    label.delete()
+                except GithubException:
+                    logging.exception(f"Error deleting label: {name}")
+                    del_fail.append(name)
+                else:
+                    del_ok.append(name)
+
+    if not dry_run:
+        print_sameline("Done.", last_line=True)
+
+    if len(add_fail) > 0:
+        logger.info(f"Failed to add labels to {src_repo}:")
+        print_list(add_fail, " [!] ")
+    if len(upd_fail) > 0:
+        logger.info(f"Failed to update labels in {src_repo}:")
+        print_list(add_fail, " [!] ")
+    if len(del_fail) > 0:
+        logger.info(f"Failed to delete labels from {src_repo}:")
+        print_list(del_fail, " [!] ")
+
+
+def print_sameline(msg, last_line=False):
+    sys.stdout.write("\033[K") # Clear prior printed line
+    if not last_line:
+        print(msg, end="\r")
+    else:
+        print(msg)
+
+
+def get_access_token():
+    """Grab Github API token from environment variable"""
+    api_key = os.environ.get("GITHUB_API_KEY", None)
+    if api_key is None:
+        raise RuntimeError("No environment variable GITHUB_API_KEY defined")
+    return api_key
+
+
+def print_list(lst, bull):
+    """Print a list, one item per line, starting with string bull"""
+    for item in sorted(lst):
+        logger.info(f"{bull}{item}")
+
+
+def main(sysargs=sys.argv[1:]):
+
+    parser = get_argument_parser(sysargs)
+    args = parser.parse_args(sysargs)
+
+    logger.info("="*30)
+    logger.info(f"{os.path.basename(__file__)}: Syncing labels from {args.src} to {args.dst}")
+    sync_labels(args.src, args.dst, args.dry_run, args.delete)
+
+
+def get_argument_parser(sysargs):
+    """Assemble and return an argument parser object"""
+
+    parser = argparse.ArgumentParser(prog="Sync Github Labels")
+    parser.add_argument(
+        "src",
+        metavar="source_repo",
+        help="Source Github repo for label sync process, in the form username/reponame or orgname/reponame",
+    )
+    parser.add_argument(
+        "dst",
+        metavar="destination_repo",
+        help="Destination Github repo for label sync process, in the form username/reponame or orgname/reponame",
+    )
+    parser.add_argument(
+        "--dry-run",
+        "-n",
+        help="Do a dry run (no labels are changed in the destination repo)",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--delete",
+        "-d",
+        help="Delete labels that are in destination repo and not in source repo",
+        action="store_true",
+    )
+    return parser
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add a script that copies Github labels from one repo to another. Related to #1.

Transcript of output from script usage:

```
$ git clone -b issues/chmreid/1-github-labels-inconsistent git@github.com:DataBiosphere/sync-github-labels.git
Cloning into 'sync-github-labels'...
remote: Enumerating objects: 27, done.
remote: Counting objects: 100% (27/27), done.
remote: Compressing objects: 100% (18/18), done.
remote: Total 27 (delta 9), reused 24 (delta 6), pack-reused 0
Receiving objects: 100% (27/27), 9.19 KiB | 4.60 MiB/s, done.
Resolving deltas: 100% (9/9), done.

$ cd sync-github-labels

$ vp
Running virtualenv with interpreter /Users/charles/.pyenv/shims/python3.6
Already using interpreter /Users/charles/.pyenv/versions/3.6.9/bin/python3.6
Using base prefix '/Users/charles/.pyenv/versions/3.6.9'
New python executable in /private/tmp/sync-github-labels/vp/bin/python3.6
Also creating executable in /private/tmp/sync-github-labels/vp/bin/python
Installing setuptools, pip, wheel...
done.

(vp)
$ pip install -r requirements.txt
Collecting certifi==2019.11.28
  Using cached certifi-2019.11.28-py2.py3-none-any.whl (156 kB)
Collecting chardet==3.0.4
  Using cached chardet-3.0.4-py2.py3-none-any.whl (133 kB)
Collecting Deprecated==1.2.7
  Using cached Deprecated-1.2.7-py2.py3-none-any.whl (8.3 kB)
Collecting idna==2.9
  Using cached idna-2.9-py2.py3-none-any.whl (58 kB)
Collecting PyGithub==1.47
  Using cached PyGithub-1.47-py3-none-any.whl (208 kB)
Collecting PyJWT==1.7.1
  Using cached PyJWT-1.7.1-py2.py3-none-any.whl (18 kB)
Collecting requests==2.23.0
  Using cached requests-2.23.0-py2.py3-none-any.whl (58 kB)
Collecting urllib3==1.25.8
  Using cached urllib3-1.25.8-py2.py3-none-any.whl (125 kB)
Processing /Users/charles/Library/Caches/pip/wheels/32/42/7f/23cae9ff6ef66798d00dc5d659088e57dbba01566f6c60db63/wrapt-1.12.1-cp36-cp36m-macosx_10_7_x86_64.whl
Installing collected packages: certifi, chardet, wrapt, Deprecated, idna, PyJWT, urllib3, requests, PyGithub
Successfully installed Deprecated-1.2.7 PyGithub-1.47 PyJWT-1.7.1 certifi-2019.11.28 chardet-3.0.4 idna-2.9 requests-2.23.0 urllib3-1.25.8 wrapt-1.12.1

(vp)
$ ./sync_labels.py --dry-run databiosphere/azul chmreid/foo-bar
Syncing labels from databiosphere/azul to databiosphere/azul
The following labels will be created in chmreid/foo-bar:
 [+] 1 review
 [+] 2 reviews
 [+] 3 reviews
 [+] 4+ reviews
 [+] API
 [+] DNAStack
 [+] HCA
 [+] arch
 [+] broad
 [+] chain
 [+] code
 [+] commons
 [+] critical
 [+] dashboard
 [+] data
 [+] debt
 [+] demo blocked
 [+] demoed
 [+] do not close
 [+] doc
 [+] enh
 [+] epic
 [+] hold warm
 [+] infra
 [+] needs info
 [+] no demo
 [+] no pr
 [+] orange
 [+] port
 [+] sandbox
 [+] security
 [+] spike
 [+] task
 [+] test
 [+] urgent
 [+] workaround
Creating label debt in destination repo chmreid/foo-bar...
Dry run successful!
Creating label 2 reviews in destination repo chmreid/foo-bar...
Dry run successful!
Creating label port in destination repo chmreid/foo-bar...
Dry run successful!
Creating label API in destination repo chmreid/foo-bar...
Dry run successful!
Creating label data in destination repo chmreid/foo-bar...
Dry run successful!
Creating label broad in destination repo chmreid/foo-bar...
Dry run successful!
Creating label do not close in destination repo chmreid/foo-bar...
Dry run successful!
Creating label arch in destination repo chmreid/foo-bar...
Dry run successful!
Creating label 3 reviews in destination repo chmreid/foo-bar...
Dry run successful!
Creating label DNAStack in destination repo chmreid/foo-bar...
Dry run successful!
Creating label epic in destination repo chmreid/foo-bar...
Dry run successful!
Creating label task in destination repo chmreid/foo-bar...
Dry run successful!
Creating label spike in destination repo chmreid/foo-bar...
Dry run successful!
Creating label critical in destination repo chmreid/foo-bar...
Dry run successful!
Creating label orange in destination repo chmreid/foo-bar...
Dry run successful!
Creating label chain in destination repo chmreid/foo-bar...
Dry run successful!
Creating label doc in destination repo chmreid/foo-bar...
Dry run successful!
Creating label needs info in destination repo chmreid/foo-bar...
Dry run successful!
Creating label dashboard in destination repo chmreid/foo-bar...
Dry run successful!
Creating label test in destination repo chmreid/foo-bar...
Dry run successful!
Creating label no demo in destination repo chmreid/foo-bar...
Dry run successful!
Creating label security in destination repo chmreid/foo-bar...
Dry run successful!
Creating label no pr in destination repo chmreid/foo-bar...
Dry run successful!
Creating label workaround in destination repo chmreid/foo-bar...
Dry run successful!
Creating label code in destination repo chmreid/foo-bar...
Dry run successful!
Creating label 4+ reviews in destination repo chmreid/foo-bar...
Dry run successful!
Creating label demo blocked in destination repo chmreid/foo-bar...
Dry run successful!
Creating label demoed in destination repo chmreid/foo-bar...
Dry run successful!
Creating label sandbox in destination repo chmreid/foo-bar...
Dry run successful!
Creating label hold warm in destination repo chmreid/foo-bar...
Dry run successful!
Creating label 1 review in destination repo chmreid/foo-bar...
Dry run successful!
Creating label infra in destination repo chmreid/foo-bar...
Dry run successful!
Creating label commons in destination repo chmreid/foo-bar...
Dry run successful!
Creating label HCA in destination repo chmreid/foo-bar...
Dry run successful!
Creating label enh in destination repo chmreid/foo-bar...
Dry run successful!
Creating label urgent in destination repo chmreid/foo-bar...
Dry run successful!
Done.

(vp)
$ ./sync_labels.py databiosphere/azul chmreid/foo-bar
Syncing labels from databiosphere/azul to databiosphere/azul
The following labels will be created in chmreid/foo-bar:
 [+] 1 review
 [+] 2 reviews
 [+] 3 reviews
 [+] 4+ reviews
 [+] API
 [+] DNAStack
 [+] HCA
 [+] arch
 [+] broad
 [+] chain
 [+] code
 [+] commons
 [+] critical
 [+] dashboard
 [+] data
 [+] debt
 [+] demo blocked
 [+] demoed
 [+] do not close
 [+] doc
 [+] enh
 [+] epic
 [+] hold warm
 [+] infra
 [+] needs info
 [+] no demo
 [+] no pr
 [+] orange
 [+] port
 [+] sandbox
 [+] security
 [+] spike
 [+] task
 [+] test
 [+] urgent
 [+] workaround
Creating label needs info in destination repo chmreid/foo-bar...
Success!
Creating label enh in destination repo chmreid/foo-bar...
Success!
Creating label sandbox in destination repo chmreid/foo-bar...
Success!
Creating label test in destination repo chmreid/foo-bar...
Success!
Creating label HCA in destination repo chmreid/foo-bar...
Success!
Creating label debt in destination repo chmreid/foo-bar...
Success!
Creating label broad in destination repo chmreid/foo-bar...
Success!
Creating label port in destination repo chmreid/foo-bar...
Success!
Creating label infra in destination repo chmreid/foo-bar...
Success!
Creating label security in destination repo chmreid/foo-bar...
Success!
Creating label chain in destination repo chmreid/foo-bar...
Success!
Creating label workaround in destination repo chmreid/foo-bar...
Success!
Creating label API in destination repo chmreid/foo-bar...
Success!
Creating label no demo in destination repo chmreid/foo-bar...
Success!
Creating label dashboard in destination repo chmreid/foo-bar...
Success!
Creating label doc in destination repo chmreid/foo-bar...
Success!
Creating label do not close in destination repo chmreid/foo-bar...
Success!
Creating label 1 review in destination repo chmreid/foo-bar...
Success!
Creating label orange in destination repo chmreid/foo-bar...
Success!
Creating label demo blocked in destination repo chmreid/foo-bar...
Success!
Creating label hold warm in destination repo chmreid/foo-bar...
Success!
Creating label 4+ reviews in destination repo chmreid/foo-bar...
Success!
Creating label DNAStack in destination repo chmreid/foo-bar...
Success!
Creating label critical in destination repo chmreid/foo-bar...
Success!
Creating label spike in destination repo chmreid/foo-bar...
Success!
Creating label epic in destination repo chmreid/foo-bar...
Success!
Creating label 2 reviews in destination repo chmreid/foo-bar...
Success!
Creating label task in destination repo chmreid/foo-bar...
Success!
Creating label 3 reviews in destination repo chmreid/foo-bar...
Success!
Creating label demoed in destination repo chmreid/foo-bar...
Success!
Creating label arch in destination repo chmreid/foo-bar...
Success!
Creating label urgent in destination repo chmreid/foo-bar...
Success!
Creating label commons in destination repo chmreid/foo-bar...
Success!
Creating label no pr in destination repo chmreid/foo-bar...
Success!
Creating label code in destination repo chmreid/foo-bar...
Success!
Creating label data in destination repo chmreid/foo-bar...
Success!
Done.

$ ./sync_labels.py --delete --dry-run databiosphere/azul chmreid/foo-bar
Syncing labels from databiosphere/azul to databiosphere/azul
The following labels will be created in chmreid/foo-bar:
The following labels will be deleted in chmreid/foo-bar:
 [-] bar
 [-] documentation
 [-] enhancement
 [-] foo
 [-] good first issue
 [-] help wanted
Removing label foo from destination repo chmreid/foo-bar...
Dry run successful!
Removing label good first issue from destination repo chmreid/foo-bar...
Dry run successful!
Removing label documentation from destination repo chmreid/foo-bar...
Dry run successful!
Removing label enhancement from destination repo chmreid/foo-bar...
Dry run successful!
Removing label bar from destination repo chmreid/foo-bar...
Dry run successful!
Removing label help wanted from destination repo chmreid/foo-bar...
Dry run successful!
Done.

$ ./sync_labels.py --delete databiosphere/azul chmreid/foo-bar
Syncing labels from databiosphere/azul to databiosphere/azul
The following labels will be created in chmreid/foo-bar:
The following labels will be deleted in chmreid/foo-bar:
 [-] bar
 [-] documentation
 [-] enhancement
 [-] foo
 [-] good first issue
 [-] help wanted
Removing label documentation from destination repo chmreid/foo-bar...
Success!
Removing label enhancement from destination repo chmreid/foo-bar...
Success!
Removing label bar from destination repo chmreid/foo-bar...
Success!
Removing label good first issue from destination repo chmreid/foo-bar...
Success!
Removing label foo from destination repo chmreid/foo-bar...
Success!
Removing label help wanted from destination repo chmreid/foo-bar...
Success!
Done.
```